### PR TITLE
Fixed issue in keyCatOrigin method of the index.ts file where it look…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,10 +147,7 @@ class Keycat {
       const url = new URL(__keycatOrigin || name)
       return url.origin
     } catch (err) {
-      if (err.message.includes('Invalid URL')) {
-        return `https://${name}.keycat.co`
-      }
-      throw err
+      return `https://${name}.keycat.co`
     }
   }
 


### PR DESCRIPTION
Fixed issue in keyCatOrigin method of the index.ts file where it looks for a specific message in an exception in order to return url or throw exception, the problem is that the error thrown in safari does not include this message and so instead of returning a url it throws and exception and fails